### PR TITLE
Establish architecture and agent baseline

### DIFF
--- a/.agents/skills/domain-modeling/ADR-FORMAT.md
+++ b/.agents/skills/domain-modeling/ADR-FORMAT.md
@@ -1,0 +1,11 @@
+# ADR format
+
+ADRs live under `docs/adr/` and use sequential filenames such as `0001-public-check-spi.md`.
+
+```markdown
+# Short decision title
+
+One to three sentences explaining the context, accepted decision, and why it was selected.
+```
+
+Optional status, considered-options, or consequences sections should be added only when they preserve important context.

--- a/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
+++ b/.agents/skills/domain-modeling/CONTEXT-FORMAT.md
@@ -1,0 +1,18 @@
+# CONTEXT.md format
+
+Use one root `CONTEXT.md` for this repository's single bounded context.
+
+```markdown
+# KlumCast
+
+One or two sentences defining the product boundary.
+
+## Language
+
+**Canonical term**:
+One or two sentences defining the concept.
+_Avoid_: Conflicting synonym, overloaded term
+```
+
+Include only KlumCast-specific product concepts. Keep definitions concise and exclude implementation choices, plans, and
+general programming terminology.

--- a/.agents/skills/domain-modeling/SKILL.md
+++ b/.agents/skills/domain-modeling/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: domain-modeling
+description: Build and sharpen repository domain language and record durable architectural decisions.
+---
+
+Read root `CONTEXT.md` and relevant files under `docs/adr/` before changing domain language or architecture.
+
+Challenge vague or conflicting terms with concrete source and usage scenarios. Use the repository's canonical vocabulary
+in issues, tests, proposals, and documentation. When a term is confirmed, update `CONTEXT.md` using
+`CONTEXT-FORMAT.md`; keep implementation details and unconfirmed designs out of the glossary.
+
+Create an ADR using `ADR-FORMAT.md` only when the accepted decision is hard to reverse, surprising without context, and
+the result of a real trade-off. Surface conflicts with existing ADRs instead of silently overriding them.

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: grilling
+description: Grill the user about a plan or design, resolving one decision at a time before implementation.
+---
+
+Explore the repository before asking questions. If a fact is discoverable from source, tests, history, documentation, or
+the issue tracker, find it rather than asking the user.
+
+Walk the design tree in dependency order. Ask exactly one decision question at a time, give a recommended answer with its
+evidence and trade-offs, and wait for the user's response. Do not reopen an accepted answer without contradictory evidence.
+
+Record confirmed domain language in `CONTEXT.md` immediately. Offer an ADR only for a confirmed decision that is hard to
+reverse, surprising without context, and the result of a real trade-off. Do not enact unconfirmed product or architecture
+decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent guidance
+
+## Issue tracker
+
+Issues and design work for this repository live in GitHub Issues. External pull requests are not a request surface. See
+`docs/agents/issue-tracker.md`.
+
+## Triage roles
+
+Use the canonical triage roles and exact repository labels documented in `docs/agents/triage-labels.md`. Apply a readiness
+label only after the issue's actual state supports that role.
+
+## Domain documentation
+
+This repository is one bounded context. Read root `CONTEXT.md` before architecture or API work and record accepted,
+durable trade-offs under `docs/adr/`. See `docs/agents/domain.md`.
+
+## Coding and testing
+
+Follow `docs/agents/coding-style.md`. The current build targets JDK 11 and verifies Groovy 2.4, 3, and 4 using the commands
+and lane policy in `docs/agents/testing.md`. Issue #455 owns any cross-repository multi-Groovy redesign.
+
+## Issue branches and commits
+
+Implement issues on a dedicated branch using small, reasoned commits. Review and, when useful, rewrite local history before
+first publication; once review begins, preserve reviewed commits and add follow-up commits. See `docs/agents/commits.md`.
+
+## Pull requests and releases
+
+Keep issue links, compatibility notes, test evidence, public documentation, and release-facing documentation consistent
+with user-visible changes. Respond to review feedback once with a consolidated disposition. See
+`docs/agents/pull-requests.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# KlumCast
+
+KlumCast is a compile-time annotation-use validation library for Groovy compilation. Consumers declare reusable
+constraints on annotation types and members; KlumCast runs checks against target AST nodes and emits source-positioned
+diagnostics during semantic analysis. Consumers that depend on successful validation perform their main transformation
+in a later compilation phase. KlumCast is not a runtime model-validation library and does not own consumer-framework
+semantics.
+
+## Language
+
+**Validated annotation**:
+A consumer-defined annotation whose uses KlumCast validates.
+_Avoid_: Annotation under check, target annotation
+
+**Validation annotation**:
+A reusable declarative annotation that contributes one or more checks to a validated annotation. Validation annotations may
+be composed from other validation annotations.
+_Avoid_: Jury annotation
+
+**Target**:
+The Groovy AST node on which a validated annotation is used.
+_Avoid_: Annotation target when referring to the annotation type's Java `@Target` declaration
+
+**Check**:
+Validation logic bound declaratively to a validation annotation and evaluated for a target. Consumers may author checks
+as a supported KlumCast extension capability.
+_Avoid_: Validator when referring to the executable check implementation
+
+**Check context**:
+The immutable description of one check invocation, including the validated annotation, target, applicable validation
+annotation, member context, binding metadata, and composition path. It intentionally exposes Groovy compiler AST types.
+_Avoid_: Mutable check state, annotation stack
+
+**Filter**:
+A condition that determines whether a validation annotation or check applies to a target.
+
+**Diagnostic**:
+A source-positioned compiler failure produced when an annotation use violates a declared constraint. Diagnostics are
+expected check outcomes; broken checks, bindings, and framework execution are technical failures instead.
+_Avoid_: Runtime validation error
+
+**Technical failure**:
+An unexpected failure of a check implementation, declarative binding, or the KlumCast engine. A technical failure is not a
+diagnostic about consumer annotation usage.
+_Avoid_: Constraint violation

--- a/docs/adr/0001-consumer-authored-checks-are-a-supported-spi.md
+++ b/docs/adr/0001-consumer-authored-checks-are-a-supported-spi.md
@@ -1,0 +1,6 @@
+# Consumer-authored checks are a supported SPI
+
+KlumCast supports consumer-authored checks as a core extension capability, not as an incidental implementation hook.
+Consumers must be able to bind their own declarative validation annotations to check implementations without owning a
+parallel transformation; the current `checks.impl` package, mutable base-class fields, annotation-stack representation,
+and reflective construction mechanism are not thereby accepted as the permanent SPI shape.

--- a/docs/adr/0002-checks-receive-an-immutable-context.md
+++ b/docs/adr/0002-checks-receive-an-immutable-context.md
@@ -1,0 +1,6 @@
+# Checks receive an immutable invocation context
+
+Each check invocation receives one immutable check context instead of being configured through mutable protected fields
+plus separate method parameters. The context provides the validated annotation, target, typed control annotation when
+present, member context, binding metadata, and composition path; the eventual interface-versus-base-class shape and
+diagnostic result mechanism remain separate decisions.

--- a/docs/adr/0003-constraint-violations-are-diagnostics.md
+++ b/docs/adr/0003-constraint-violations-are-diagnostics.md
@@ -1,0 +1,5 @@
+# Constraint violations are diagnostics
+
+Expected constraint violations are explicit source-positioned diagnostic data, and one check may produce zero or more of
+them. Unexpected failures in a check, binding, or the KlumCast engine remain technical failures with their causes preserved;
+legacy `ValidationException` and runtime-exception behavior may be adapted for migration but does not define the new SPI.

--- a/docs/adr/0004-the-check-spi-exposes-groovy-ast-types.md
+++ b/docs/adr/0004-the-check-spi-exposes-groovy-ast-types.md
@@ -1,0 +1,6 @@
+# The check SPI exposes Groovy AST types
+
+The supported check SPI intentionally exposes Groovy compiler AST types because KlumCast is Groovy-specific and custom
+checks need the compiler's full target model. The artifact that owns the SPI must therefore publish Groovy as an explicit
+API dependency, and public documentation must state the supported Groovy compatibility contract rather than presenting
+the dependency as an internal `compileOnly` detail.

--- a/docs/adr/0005-separate-metadata-spi-and-compiler-roles.md
+++ b/docs/adr/0005-separate-metadata-spi-and-compiler-roles.md
@@ -1,0 +1,6 @@
+# Separate metadata, check SPI, and compiler roles
+
+KlumCast separates three artifact roles: lightweight declarative annotations and metadata without a transitive Groovy
+compiler dependency; a Groovy-dependent public check SPI; and the compiler engine with built-in implementations and
+activation. Exact coordinates and compatibility bridges remain open, but AST-dependent SPI types must not remain in the
+metadata artifact while its published POM hides Groovy.

--- a/docs/adr/0006-activate-validation-from-the-compiler-artifact.md
+++ b/docs/adr/0006-activate-validation-from-the-compiler-artifact.md
@@ -1,0 +1,8 @@
+# Activate validation from the compiler artifact
+
+KlumCast uses a service-loaded global AST transformation as its default supported activation mechanism. Adding the
+compiler artifact to a Groovy compilation classpath explicitly activates validation; the metadata and check-SPI artifacts
+remain inert. This keeps activation independent of any particular build tool and avoids requiring per-annotation
+registration. The compiler artifact's documentation must make its ambient effect and scanning scope explicit, while
+transformation phase, ordering guarantees, opt-out behavior, and any future manual activation hook remain separate
+decisions.

--- a/docs/adr/0007-validate-during-semantic-analysis.md
+++ b/docs/adr/0007-validate-during-semantic-analysis.md
@@ -1,0 +1,7 @@
+# Validate during semantic analysis
+
+KlumCast validates annotation state during Groovy's `SEMANTIC_ANALYSIS` phase. It guarantees that validation completes
+before consumer transformations scheduled in later phases, so consumers that depend on successful validation should
+perform their main mutation in `CANONICALIZATION` or later. KlumCast does not guarantee ordering relative to other
+transformations in `SEMANTIC_ANALYSIS`; same-phase annotation synthesis or mutation requires a future explicit
+coordination mechanism rather than relying on incidental transform order.

--- a/docs/adr/0008-control-activation-through-dependency-placement.md
+++ b/docs/adr/0008-control-activation-through-dependency-placement.md
@@ -1,0 +1,7 @@
+# Control activation through dependency placement
+
+Dependency placement is KlumCast's supported activation control: adding the compiler artifact to the Groovy compilation
+classpath enables its service-loaded transformation, and removing that artifact disables it while metadata and check-SPI
+artifacts remain inert. KlumCast does not initially provide a runtime flag, system property, or source-level opt-out,
+because hidden environmental state would make validation inconsistent. A more granular opt-out may be added only for a
+concrete tooling or embedding use case that cannot control its compilation classpath.

--- a/docs/adr/0009-service-loading-is-the-only-supported-activation-api.md
+++ b/docs/adr/0009-service-loading-is-the-only-supported-activation-api.md
@@ -1,0 +1,6 @@
+# Service loading is the only supported activation API
+
+Service loading is KlumCast's only supported activation API at this stage. The compiler engine should remain internally
+separable and directly testable, but KlumCast does not promise a public manual invocation hook without a concrete
+compiler-embedding use case and a defined lifecycle contract. This avoids freezing Groovy compiler orchestration details
+as an additional public SPI.

--- a/docs/adr/0010-support-typed-and-name-based-check-bindings.md
+++ b/docs/adr/0010-support-typed-and-name-based-check-bindings.md
@@ -1,0 +1,17 @@
+# Support typed and name-based check bindings
+
+Status: accepted after the proof of concept under `docs/implementation/prototypes/check-binding/` passed with Groovy 3
+and 4.
+
+KlumCast supports both typed check-class bindings and fully qualified implementation-class-name bindings. The metadata
+artifact owns name-based binding for lightweight and cyclic split-module designs. The SPI artifact owns strongly typed
+`Class<? extends Check>` binding for co-located and nested checks. A binding selects exactly one mode, and the compiler
+normalizes both forms. Named implementations are resolved with the compilation classloader and verified against the check
+SPI; missing, incompatible, or ambiguous bindings are technical configuration failures rather than annotation-use
+diagnostics.
+
+The existing mixed annotation's typed member may become a deprecated metadata-owned `Class<?>` migration bridge for a
+documented window. The POC proved that this preserves the JVM method descriptor but loses source-level type rejection;
+new typed declarations therefore use the SPI-owned annotation. It also proved nested-check ergonomics, compile-time type
+rejection, name-based split-module ordering, class loading, and automatic-module behavior. KlumCast does not abstract
+Groovy AST types to manufacture a dependency-free check interface.

--- a/docs/adr/0011-use-an-interface-for-the-check-spi.md
+++ b/docs/adr/0011-use-an-interface-for-the-check-spi.md
@@ -1,0 +1,7 @@
+# Use an interface for the check SPI
+
+The durable check SPI is a minimal Java interface whose operation accepts the immutable check context and returns
+diagnostics. Check authors do not extend a required KlumCast base class; reusable behavior belongs in separate utilities
+or optional convenience types. The current `KlumCastCheck` abstract class is migration surface rather than the permanent
+contract, avoiding inherited mutable state and preserving consumers' freedom to choose their own implementation
+inheritance.

--- a/docs/adr/0012-engine-owned-check-lifecycle.md
+++ b/docs/adr/0012-engine-owned-check-lifecycle.md
@@ -1,0 +1,7 @@
+# Use engine-owned, compilation-scoped check instances
+
+Check implementations are concrete classes with an accessible no-argument constructor. The compiler engine owns their
+lifecycle and may instantiate per binding or reuse instances within one compilation; checks must not depend on instance
+identity, invocation count, or retained state. Instances are not shared across compilation runs, avoiding classloader
+retention. Constructor injection, service registries, and custom factories remain out of scope until a concrete dependency
+injection requirement emerges.

--- a/docs/adr/0013-keep-applicability-separate-from-check-success.md
+++ b/docs/adr/0013-keep-applicability-separate-from-check-success.md
@@ -1,0 +1,8 @@
+# Keep applicability separate from check success
+
+Applicability is a first-class concept distinct from check success: a filtered-out check is not applicable, which must not
+be treated as a successful branch by boolean composition. KlumCast retains a supported applicability-filter SPI, redesigned
+as a stateless interface receiving immutable context rather than the mutable `Filter.Function` base class. Declarative
+target-kind filters remain built in, custom filters support typed and name-based bindings under the same resolution rules
+as checks, and all filters attached to one binding are conjunctive unless an explicit composition strategy defines
+otherwise.

--- a/docs/adr/0014-use-structured-source-positioned-diagnostics.md
+++ b/docs/adr/0014-use-structured-source-positioned-diagnostics.md
@@ -1,0 +1,7 @@
+# Use structured, source-positioned diagnostics
+
+A KlumCast constraint diagnostic is immutable and contains a stable check-scoped code, a rendered human-readable message,
+a primary Groovy AST node, optional structured message arguments and related AST nodes, and engine-attached provenance for
+the check binding and composition path. Constraint diagnostics remain compiler errors initially; customizable severity
+requires a concrete warning use case. Technical failures remain outside the diagnostic payload. Message override mechanics
+for validation annotations are a separate decision.

--- a/docs/adr/0015-keep-any-ide-integration-outside-compiler-core.md
+++ b/docs/adr/0015-keep-any-ide-integration-outside-compiler-core.md
@@ -1,0 +1,6 @@
+# Keep any IDE integration outside compiler core
+
+IDE integration is speculative and is not a roadmap commitment. If pursued, it lives in a separate integration layer that
+consumes KlumCast's structured diagnostics; IntelliJ or other IDE APIs do not enter the compiler core. Editor completion
+may eventually justify a read-only metadata or query API, but that API must be driven by concrete completion scenarios
+rather than anticipated now. No GitHub issue or core API requirement is created by this conditional boundary.

--- a/docs/adr/0016-override-diagnostic-messages-by-code.md
+++ b/docs/adr/0016-override-diagnostic-messages-by-code.md
@@ -1,0 +1,7 @@
+# Override diagnostic messages by code
+
+Checks own default messages and stable check-scoped diagnostic codes. A validation annotation may expose optional
+message-template members keyed to those codes, using named structured arguments rather than positional formatting. In a
+composed validation annotation, the nearest applicable override in the composition path wins; absent overrides use the
+check default. Unknown codes and invalid templates are technical configuration failures. Exact annotation names and
+template syntax remain implementation details to select with issue #17.

--- a/docs/adr/0017-use-annotations-spi-and-compile-artifacts.md
+++ b/docs/adr/0017-use-annotations-spi-and-compile-artifacts.md
@@ -1,0 +1,8 @@
+# Use annotations, SPI, and compile artifacts
+
+KlumCast preserves `klum-cast-annotations` as the lightweight declarative metadata and built-in-validation-annotation
+artifact, introduces `klum-cast-spi` for the Groovy-dependent check, filter, context, and diagnostic contracts, and keeps
+`klum-cast-compile` for the engine, built-in implementations, and service-loaded activation. The compile artifact depends
+on annotations and SPI. There is no aggregator artifact or rename of `compile` without a demonstrated need. Custom-check
+authors must add the explicit SPI dependency, and moving the existing base-class API requires a documented breaking
+migration and release plan.

--- a/docs/adr/0018-assign-packages-to-one-artifact.md
+++ b/docs/adr/0018-assign-packages-to-one-artifact.md
@@ -1,0 +1,7 @@
+# Assign each package to one artifact
+
+KlumCast preserves `com.blackbuild.klum.cast` and `com.blackbuild.klum.cast.checks` for declarative metadata and built-in
+validation annotations, places durable public extension contracts under `com.blackbuild.klum.cast.spi`, and places the
+engine and built-in implementations in compiler-owned packages such as `com.blackbuild.klum.cast.compiler.internal`. No
+package is split across artifacts. The old `com.blackbuild.klum.cast.checks.impl.KlumCastCheck` name may live temporarily
+and exclusively in the SPI artifact as a deprecated migration adapter, but it is not a permanent public package.

--- a/docs/adr/0019-keep-annotations-and-spi-as-sibling-dependencies.md
+++ b/docs/adr/0019-keep-annotations-and-spi-as-sibling-dependencies.md
@@ -1,0 +1,7 @@
+# Keep annotations and SPI as sibling dependencies
+
+`klum-cast-annotations` and `klum-cast-spi` do not depend on each other. Annotations owns lightweight name-based binding;
+SPI owns typed binding and publicly depends on the Groovy compiler API. `klum-cast-compile` depends on both sibling
+artifacts and normalizes their binding forms into SPI-owned invocation data. This avoids both an annotations-to-SPI cycle
+and an unnecessary SPI-to-annotations edge while allowing one compiler dependency to supply everything needed for
+activation.

--- a/docs/adr/0020-publish-stable-automatic-module-names-first.md
+++ b/docs/adr/0020-publish-stable-automatic-module-names-first.md
@@ -1,0 +1,7 @@
+# Publish stable automatic module names first
+
+KlumCast assigns stable module identities `com.blackbuild.klum.cast.annotations`, `com.blackbuild.klum.cast.spi`, and
+`com.blackbuild.klum.cast.compiler`, initially through `Automatic-Module-Name` while retaining classpath support. Explicit
+module descriptors require a Groovy 3/4/5 feasibility proof covering compilation, service loading, and classpath use,
+because Groovy's module identity changes from `org.codehaus.groovy` to `org.apache.groovy`. That proof coordinates with
+KlumAST #455 without selecting its multi-Groovy design.

--- a/docs/adr/0021-use-0-4-as-the-migration-line-before-1-0.md
+++ b/docs/adr/0021-use-0-4-as-the-migration-line-before-1-0.md
@@ -1,0 +1,7 @@
+# Use 0.4 as the migration line before 1.0
+
+KlumCast uses `0.4.x` as a transitional, explicitly breaking migration line. `0.4.0` introduces the three-artifact layout,
+stable module names, new SPI, dual bindings, and structured diagnostics while retaining the deprecated base-class adapter
+and raw typed-member bridge. Release-facing documentation must enumerate dependency, import, binding, and diagnostic
+changes. `0.3.x` receives only necessary fixes. `1.0.0` removes the temporary bridges and begins the durable compatibility
+promise on the clean architecture.

--- a/docs/adr/0022-define-an-explicit-post-1-0-compatibility-surface.md
+++ b/docs/adr/0022-define-an-explicit-post-1-0-compatibility-surface.md
@@ -1,0 +1,8 @@
+# Define an explicit post-1.0 compatibility surface
+
+Beginning with 1.0, KlumCast treats published artifact coordinates and stable module names; exported metadata,
+built-in-annotation, and SPI packages; public annotation/interface/data-type shape; diagnostic codes and structured
+argument names; binding resolution and activation behavior; declared dependency edges; and the documented Java/Groovy
+support matrix as compatibility commitments. Compiler internals, service-provider implementation names, built-in check
+implementation names, default message wording, and rendering details are not API. Removing a supported Groovy generation
+requires a major release unless it is already outside a documented support window.

--- a/docs/adr/0023-render-each-diagnostic-as-a-native-compiler-error.md
+++ b/docs/adr/0023-render-each-diagnostic-as-a-native-compiler-error.md
@@ -1,0 +1,7 @@
+# Render each diagnostic as a native compiler error
+
+The compiler adapter emits one native Groovy compiler error for each KlumCast diagnostic, includes the stable diagnostic
+code in rendered text, and uses the diagnostic's primary AST node for positioning. Related locations and composition
+provenance render as supplementary context rather than extra failures. Independent diagnostics are emitted in deterministic
+source and binding order instead of being collapsed. Technical failures are reported separately with binding identity and
+preserved causes. The structured diagnostic is authoritative; Groovy-specific rendering remains an adapter detail.

--- a/docs/adr/0024-test-artifact-contracts-and-consumer-scenarios.md
+++ b/docs/adr/0024-test-artifact-contracts-and-consumer-scenarios.md
@@ -1,0 +1,8 @@
+# Test artifact contracts and consumer scenarios
+
+KlumCast tests each artifact at its responsibility boundary: metadata shape and Groovy-free publication for annotations;
+immutability, diagnostics, filters, typed binding, and Groovy compatibility for SPI; and end-to-end activation, ordering,
+bindings, custom checks, diagnostics, technical failures, and composition for compile. Packaging fixtures verify published
+dependencies, stable module names, service discovery, no split packages, and classpath/module-path use. Consumer fixtures
+cover nested typed checks and split name bindings. Coverage is reported per code-bearing artifact, but risk-based scenario
+gates rather than one aggregate percentage determine release readiness.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture decision records
+
+This directory records accepted, durable architectural trade-offs for the single KlumCast context. ADRs use sequential
+filenames such as `0001-public-check-spi.md` and explain the decision and why it was selected. Product vocabulary belongs
+in root `CONTEXT.md`; investigation notes and unconfirmed alternatives do not belong here.

--- a/docs/agents/coding-style.md
+++ b/docs/agents/coding-style.md
@@ -1,0 +1,14 @@
+# Coding style
+
+Follow the conventions already established in the surrounding module.
+
+## Imports and qualified names
+
+- Import referenced Java and Groovy types and use their simple names in handwritten source.
+- When two referenced types have the same simple name, import the more frequent type and qualify the other only at the
+  ambiguous use sites.
+- Fully qualified names are appropriate for string-valued class bindings, generated-source constraints, or another
+  documented technical necessity. Keep the reason visible in the API or a short comment.
+- Generated output is governed by its generator; handwritten templates should still use imports when possible.
+
+Code review treats an unnecessary fully qualified name as a style violation rather than an optional preference.

--- a/docs/agents/commits.md
+++ b/docs/agents/commits.md
@@ -1,0 +1,26 @@
+# Issue branches and commit history
+
+## Dedicated branches
+
+- Create a branch dedicated to the current issue or design task before the first commit.
+- Keep unrelated work and user-owned worktree changes out of the branch history.
+- On a newly created issue branch, agents may create and amend commits without asking until the branch is published for
+  review. Obtain permission before committing on shared or unrelated branches.
+
+## Reasoned commits
+
+- Make each commit one self-contained reasoning step with a concise imperative subject.
+- Keep a test and the production change that makes it pass in the same commit.
+- Run the relevant verification before each commit. A deliberately transitional commit must make the reasoning clearer,
+  be repaired immediately, and explain the boundary.
+- Documentation must match the final branch state.
+
+## Before first publication
+
+Inspect the complete issue-branch history and final diff. Combine, split, reorder, or reword unpublished commits when that
+improves focus and reviewability, then rerun verification on the final tip.
+
+## After review begins
+
+Human review and automated findings such as static-analysis results freeze the reviewed commits. Address feedback with
+additive, focused follow-up commits unless the maintainer explicitly requests a history rewrite.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,18 @@
+# Domain documentation
+
+KlumCast uses a single-context layout:
+
+```text
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+└── klum-cast-*/
+```
+
+Before architecture or API work, read root `CONTEXT.md` and ADRs relevant to the area. Use the glossary's canonical terms
+in issues, tests, documentation, and proposals. Surface conflicts with accepted ADRs instead of silently overriding them.
+
+`CONTEXT.md` is a glossary and product-language boundary, not an implementation specification. Add an ADR only for an
+accepted decision that is hard to reverse, surprising without context, and the result of a real trade-off. ADR filenames
+use sequential numbers such as `0001-public-check-spi.md`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,16 @@
+# Issue tracker: GitHub
+
+GitHub Issues are this repository's issue and design tracker. Infer the repository from `git remote -v` and use `gh` for
+issue operations.
+
+## Policy
+
+- Read the complete issue, comments, labels, relationships, and current state before acting.
+- Separate discoverable facts from decisions that require maintainer confirmation.
+- Do not normalize issue bodies, labels, milestones, dependencies, or state until the intended result is confirmed.
+- Use closing keywords only when the accepted issue scope is fully delivered.
+- External pull requests are not treated as feature requests.
+- Create implementation work on a dedicated issue branch as described in `docs/agents/commits.md`.
+
+Typical read-only commands are `gh issue view <number> --comments` and `gh issue list --state open --json
+number,title,body,labels,comments`.

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -1,0 +1,34 @@
+# Pull requests and release-facing documentation
+
+## Scope and issue links
+
+- Use closing keywords only for issues whose confirmed behavior is fully delivered.
+- Reference related work that remains deferred and state explicitly what the pull request does not implement.
+- Keep the summary, compatibility impact, and validation evidence current as commits are added.
+
+## Quality evidence
+
+- Review changed source against `docs/agents/coding-style.md`.
+- Follow `docs/agents/testing.md`: run focused tests during development and every supported Groovy lane before final handoff
+  when the task changes code or build behavior.
+- Inspect all required CI checks for the current revision. Green CI proves the tested state, not that unresolved product
+  decisions are complete.
+- Fix reliability and security findings. Retain a maintainability finding only with a localized suppression and a concrete
+  reason.
+
+## Review follow-up
+
+- Preserve reviewed commits and address feedback with additive commits as required by `docs/agents/commits.md`.
+- Post one consolidated follow-up response covering every observation: what changed, what intentionally did not change and
+  why, and which focused tests, compatibility lanes, CI checks, and static analysis support the result.
+- A request to address review feedback authorizes that consolidated response after changes are pushed. It does not
+  authorize resolving threads, dismissing reviews, or submitting a review.
+
+## Public and release documentation
+
+- Update `README.md` for changes to installation, artifact roles, supported environments, extension contracts, or user
+  behavior.
+- Record user-visible features, fixes, deprecations, and compatibility breaks in the repository's release-facing
+  documentation once its confirmed location exists.
+- Do not present implementation notes under `docs/` as user documentation unless the repository explicitly adopts them for
+  that purpose.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,21 @@
+# Testing
+
+KlumCast currently supports three Groovy generations on JDK 11. Passing one lane is not evidence that the others pass.
+Issue #455 owns redesign of the cross-repository multi-Groovy approach; these commands document the current repository.
+
+| Command | Groovy generation | Use |
+|---|---:|---|
+| `./gradlew test` | 2.4 | Current default and focused-development lane |
+| `./gradlew test -PgroovyVersion=3.0.17` | 3 | Compatibility check |
+| `./gradlew test -PgroovyVersion=4.0.12` | 4 | Compatibility check |
+| `./gradlew build` with the same properties | corresponding lane | Final compilation, test, license, JAR, and Javadoc evidence |
+
+Run under JDK 11. In a linked Git worktree, the current Nebula Release setup may also require
+`-Pgit.root=<path-to-main-checkout>`; treat that as a known build limitation rather than a product contract.
+
+Start with the narrowest relevant default-lane test. Run Groovy 3 and 4 when compiler APIs, AST behavior, dependency
+compatibility, classloading, or another version seam may differ, and run all three lanes before final handoff of a code or
+build change.
+
+Every ignored, conditionally ignored, or pending test must state an actionable reason and the unsupported contract or
+blocker.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,14 @@
+# Triage labels
+
+Use these canonical roles when discussing issue readiness. The right-hand column is the exact label string in this
+repository's GitHub issue tracker.
+
+| Canonical role | Current repository label | Meaning |
+|---|---|---|
+| `needs-triage` | `needs-triage` | Maintainer must evaluate scope and ownership |
+| `needs-info` | `needs-info` | Waiting for reporter or maintainer information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified and safe for autonomous implementation |
+| `ready-for-human` | `ready-for-human` | Requires a maintainer decision or human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+Existing `decision` and `breaking change` labels describe issue content; they do not replace readiness roles.

--- a/docs/implementation/architecture-and-agent-baseline.md
+++ b/docs/implementation/architecture-and-agent-baseline.md
@@ -1,0 +1,284 @@
+# Architecture and agent baseline
+
+Date: 2026-07-16
+
+This is the repository-owned evidence and decision log for the library-native architecture session requested after
+KlumAST issue #450. It separates confirmed KlumCast decisions from candidate improvements and from the cross-repository
+multi-Groovy investigation in KlumAST issue #455.
+
+## Evidence baseline
+
+- KlumCast publishes `klum-cast-annotations` and `klum-cast-compile`.
+- The annotations artifact contains the declarative validation vocabulary, embedded checks, filters, and custom-check base
+  API. Its public signatures expose Groovy AST types while its generated Maven POM declares no Groovy dependency.
+- The compile artifact depends transitively on annotations, contains external built-in checks and validation orchestration,
+  and registers a global semantic-analysis AST transformation through `META-INF/services`.
+- Both artifacts contain `com.blackbuild.klum.cast.checks.impl`, creating a split package. Neither artifact declares an
+  explicit JPMS descriptor or stable automatic-module name.
+- The current JDK 11 build passes 56 tests under Groovy 2.4.21, 3.0.17, and 4.0.12. Compile-module coverage measured under
+  Groovy 4 is 83% instructions and 74% branches; the annotations artifact has no test or coverage source set.
+- Open repository issues relevant to architecture are #12 (module descriptors), #13 (Groovy 2), #16 (check context), and
+  #17 (structured messages).
+- KlumAST consumes both artifacts through public `api` edges, defines eight string-bound custom checks, and retains two
+  validation-ownership TODOs. Those consumer facts are inputs, not KlumCast requirements.
+
+## Confirmed decisions
+
+### Product boundary
+
+KlumCast is a compile-time annotation-use validation library for Groovy compilation. It owns reusable declarative
+constraints, check orchestration, and source-positioned diagnostics during semantic analysis. Consumers that depend on
+successful validation perform their main transformation in a later compilation phase. KlumCast does not own runtime
+model validation or consumer-framework semantics.
+
+This scope is recorded as product language in root `CONTEXT.md`; the later ADRs in this plan select the artifact,
+activation, diagnostic, and extension boundaries that implement it.
+
+### Consumer-authored checks
+
+Consumer-authored checks are a supported core extension capability. KlumCast owns a deliberate public SPI that lets a
+consumer bind declarative validation annotations to its own check implementations. ADR 0001 records this commitment while
+later ADRs replace the current `checks.impl` package, mutable field injection, and annotation-stack representation with
+the package, immutable-context, binding, and migration contracts below.
+
+### Check invocation context
+
+Checks are stateless per invocation and receive one immutable check context. ADR 0002 replaces the current mixture of
+protected mutable fields and method parameters at the supported contract boundary. The context carries the validated
+annotation, target, typed control annotation when present, member context, binding metadata, and composition path; exact
+Java record/class syntax remains an implementation detail, while ADRs 0011 and 0014 define the interface and diagnostic
+result boundaries.
+
+### Diagnostics and technical failures
+
+Expected constraint violations are explicit diagnostic data, and one check may emit zero or more source-positioned
+diagnostics. Unexpected check, binding, and engine failures retain their causes as technical failures rather than being
+converted into invalid-annotation diagnostics. ADRs 0014, 0016, and 0023 define the structured fields, override model, and
+compiler presentation.
+
+### Groovy AST API boundary
+
+The supported check SPI intentionally exposes Groovy compiler AST types. ADR 0004 accepts Groovy AST as public API rather
+than introducing a limiting wrapper abstraction. The owning artifact must publish Groovy as an API dependency, and the
+README/Javadocs for the eventual SPI must document supported Groovy generations, dependency expectations, and migration
+constraints explicitly.
+
+### Artifact roles
+
+ADR 0005 separates lightweight declarative annotations/metadata, the Groovy-dependent public check SPI, and the compiler
+engine with built-in implementations and activation. This replaces the current contradiction where the annotations
+artifact exposes AST-dependent SPI types but omits Groovy from its published dependency metadata. Coordinates, package
+names, dependency edges, and compatibility bridges are resolved by ADRs 0017 through 0021.
+
+### Activation boundary
+
+ADR 0006 keeps service-loaded global AST transformation as the default supported activation mechanism and confines it to
+the compiler artifact. Adding that artifact to a Groovy compilation classpath is the explicit activation act; the metadata
+and check-SPI artifacts remain inert. The ambient effect and scan scope must be documented. ADRs 0007 through 0009 resolve
+ordering, opt-out behavior, and the absence of a public manual hook.
+
+### Transformation timing
+
+ADR 0007 retains `SEMANTIC_ANALYSIS` as KlumCast's validation phase. KlumCast guarantees completion relative to consumer
+transformations in later phases, and consumers that depend on validation should perform their main mutation in
+`CANONICALIZATION` or later. It provides no ordering guarantee relative to other semantic-analysis transformations;
+same-phase annotation synthesis or mutation needs explicit future coordination.
+
+### Activation control
+
+ADR 0008 makes dependency placement the supported activation control. Removing the compiler artifact from a Groovy
+compilation classpath disables KlumCast while leaving metadata and check-SPI artifacts usable. There is no runtime flag,
+system-property switch, or source-level opt-out without a concrete tooling or embedding requirement that cannot control
+its compilation classpath.
+
+### Activation API
+
+ADR 0009 keeps service loading as the only supported activation API. Engine orchestration remains separable enough for
+internal tests, but no public manual invocation hook is promised without a concrete embedding use case and a defined
+compiler lifecycle contract.
+
+### Declarative check binding
+
+ADR 0010 is accepted after the proof of concept. The metadata artifact owns name-based binding for lightweight and cyclic
+split-module designs; the SPI artifact owns strongly typed binding for co-located and nested checks. The compiler
+normalizes both, and a declaration selects one form. The existing mixed annotation's typed member may become a deprecated
+raw `Class<?>` bridge for a documented migration window. No Groovy AST abstraction is introduced.
+
+### Check SPI shape
+
+ADR 0011 defines the durable check SPI as a minimal Java interface that receives the immutable check context and returns
+diagnostics. No KlumCast base class is required. Reusable helpers remain separate, and the current mutable
+`KlumCastCheck` abstract class is treated as migration surface rather than the permanent contract.
+
+### Check construction and lifecycle
+
+ADR 0012 requires a concrete check implementation with an accessible no-argument constructor. The engine may construct
+per binding or reuse within one compilation, so checks cannot rely on identity, invocation count, or retained state.
+Instances do not cross compilation runs; dependency injection and custom factories require a future concrete use case.
+
+### Applicability filters
+
+ADR 0013 keeps applicability distinct from check success so composition can distinguish a filtered-out branch from a
+passing branch. Filters form a supported, stateless interface over immutable context; declarative target-kind filters stay
+built in, and custom filters have typed and name-based binding modes under the same resolution rules as checks. Filters on
+one binding remain conjunctive unless an explicit composition strategy says otherwise.
+
+### Structured diagnostics
+
+ADR 0014 defines an immutable diagnostic with a stable check-scoped code, rendered message, primary AST node, optional
+structured arguments and related nodes, and engine-attached binding/composition provenance. Constraint diagnostics remain
+compiler errors; technical failures stay outside this payload, and message overrides remain a separate decision.
+
+### Conditional IDE boundary
+
+ADR 0015 records no IDE roadmap commitment. If the speculative integration is pursued, it remains a separate layer over
+structured KlumCast diagnostics and introduces no IDE dependencies into compiler core. Completion support may motivate a
+read-only query API only after concrete scenarios exist.
+
+### Diagnostic message overrides
+
+ADR 0016 gives checks ownership of default messages and stable check-scoped codes. Validation annotations may declare
+optional message templates keyed by code and using named structured arguments. The nearest applicable override in a
+composition path wins; invalid codes or templates are technical configuration failures. Exact annotation and template
+syntax remains implementation work for issue #17.
+
+### Artifact coordinates
+
+ADR 0017 preserves `klum-cast-annotations` for lightweight metadata and built-in validation annotations, adds
+`klum-cast-spi` for Groovy-dependent extension contracts, and retains `klum-cast-compile` for the engine, implementations,
+and activation. No aggregator or coordinate rename is added. Custom-check authors add SPI explicitly, with a documented
+breaking migration from the current base-class API.
+
+### Published dependency graph
+
+ADR 0019 keeps annotations and SPI as siblings with no edge between them. SPI publicly depends on the Groovy compiler API;
+compile depends on both siblings and normalizes both binding forms. Annotation-only consumers remain Groovy-free, typed
+check authors opt into SPI, and adding compile supplies both dependencies for activation. Groovy version and variant
+selection remains owned by KlumAST #455.
+
+### JPMS identity
+
+ADR 0020 assigns stable module names `com.blackbuild.klum.cast.annotations`, `.spi`, and `.compiler`, initially through
+`Automatic-Module-Name` with continued classpath support. Explicit descriptors require a Groovy 3/4/5 feasibility proof
+that includes service loading and separate classpath coverage. The Groovy module-name transition remains a #455
+coordination fact rather than a KlumCast variant decision.
+
+### Release and migration line
+
+ADR 0021 makes `0.4.x` the transitional redesign line. It introduces the new artifact and SPI contracts with deprecated
+migration bridges and complete release-facing migration documentation; `0.3.x` is fixes-only. `1.0.0` removes temporary
+bridges and starts the durable compatibility promise on the clean architecture.
+
+### Post-1.0 compatibility surface
+
+ADR 0022 makes coordinates, stable module names, exported metadata/built-in/SPI packages, public type shapes, diagnostic
+codes and argument names, binding and activation behavior, dependency edges, and the documented Java/Groovy support matrix
+compatibility commitments. Compiler implementation identities, default message prose, and rendering details remain
+internal. Removing an in-window Groovy generation requires a major release.
+
+### Compiler diagnostic presentation
+
+ADR 0023 maps every structured diagnostic to one native Groovy compiler error with its stable code and primary AST-node
+position. Related locations and provenance are supplementary context. Independent diagnostics are emitted in deterministic
+source/binding order, while technical failures retain their cause and binding identity in a separate failure path.
+
+### KlumAST `FieldAstValidator` ownership
+
+`FieldAstValidator` and all of its DSL-object, keyed-model, link, default-implementation, and instantiability rules remain
+strictly consumer-owned by KlumAST. Its “move logic to KlumCast” TODO refers only to possible reusable node-kind dispatch
+before consumer hook methods, not ownership of those rules. This classification is intentionally not an ADR. A generic
+helper remains optional until another concrete use case demonstrates the same repetition.
+
+### KlumAST `LinkHelper` ownership
+
+The `LinkHelper` TODO contains two KlumAST-owned changes. Its single-use static methods should move into the
+`AutoLinkPhase` case class now that KlumAST has a phase model. Any remaining static `@LinkTo` annotation invariants should
+be KlumAST custom checks using KlumCast's SPI; existing `@MutuallyExclusive`, `@NotOn`, and `@AlsoNeeds` declarations have
+already moved much of that validation. Runtime provider, owner, selector, and value resolution remains KlumAST lifecycle
+behavior. This classification creates no KlumCast API or ADR.
+
+### Test and coverage seams
+
+ADR 0024 assigns tests by artifact contract: metadata and Groovy-free publication in annotations; immutable SPI,
+diagnostics, filters, typed binding, and Groovy compatibility in SPI; end-to-end compiler behavior in compile; and separate
+packaging plus representative consumer fixtures. Per-artifact coverage remains visible, but release readiness is based on
+risk scenarios including service loading, ordering, both bindings, failures, module/class paths, nested checks, and split
+consumer modules rather than one aggregate percentage.
+
+### Package ownership
+
+ADR 0018 preserves existing declarative packages, puts durable public extension contracts under
+`com.blackbuild.klum.cast.spi`, and assigns engine and implementation packages exclusively to the compiler artifact. This
+eliminates the current split package. The old `checks.impl.KlumCastCheck` name may be a temporary deprecated adapter in the
+SPI artifact only; it is not a permanent package contract.
+
+## Implementation gates and deferred decisions
+
+- #12 owns the explicit-module-descriptor feasibility POC across the supported Groovy generations; stable automatic-module
+  identities are already decided.
+- #22 owns detailed boolean composition semantics over the confirmed applicability, diagnostic, and technical-failure
+  model.
+- #23 is an optional investigation gated on a second concrete node-kind dispatch use case.
+- Exact Java type names and diagnostic-template syntax remain implementation design within #16 and #17's confirmed
+  boundaries.
+- The supported Groovy matrix and common multi-Groovy build design remain separate in #13 and KlumAST #455.
+
+No further library-native product decision is required before the focused issues can prepare implementation plans and
+proofs. Production API/build changes still require their normal issue workflow and review.
+
+Issue #455 separately owns the common multi-Groovy design. This plan may contribute facts to that issue but must not select
+its outcome.
+
+## Tracer bullets
+
+- [#24 — Deliver the 0.4 architecture and migration baseline](https://github.com/klum-dsl/klum-cast/issues/24)
+  coordinates the accepted artifact, package, dependency, activation, SPI, diagnostics, JPMS-identity, compatibility,
+  migration-documentation, and verification work. It links the focused issues without absorbing #455's multi-Groovy
+  decision, the speculative IDE idea, or KlumAST-specific validation semantics.
+
+- [#22 — Define boolean composition strategies over check outcomes](https://github.com/klum-dsl/klum-cast/issues/22)
+  follows the incomplete OR/XOR/conditional scope of #2 and #21. It will prove composition against the confirmed immutable
+  context and diagnostic/technical-failure contracts while keeping the cross-repository build design out of scope.
+
+- [#23 — Investigate reusable node-kind dispatch for consumer-authored checks](https://github.com/klum-dsl/klum-cast/issues/23)
+  compares KlumAST's consumer-owned `FieldAstValidator` pattern with klum-wrap or another independent use case. It gates
+  any helper on two concrete uses and requires an interface-compatible, immutable-context design; it does not upstream
+  KlumAST validation semantics and is intentionally not an ADR decision.
+
+- Prove the declarative binding layout before finalizing ADR 0010. Compare an SPI-owned strongly typed annotation, a
+  metadata-owned `Class<?>` compatibility bridge, and a name-only model. Compile nested check classes and invalid check
+  types; inspect published dependencies, class loading, automatic modules, and package ownership. This is an isolated
+  design experiment, not authorization to change the production API or build.
+
+  The reproducible fixture under `docs/implementation/prototypes/check-binding/` passed on Groovy 3.0.17 and 4.0.12. It
+  proves that SPI-owned typed binding preserves compile-time rejection and nested-check ergonomics; name binding preserves
+  cyclic split-module dependency direction; and a metadata-owned raw bridge preserves the JVM `Class` method descriptor
+  but not source-level type safety. It also shows that SPI need not depend on annotations: compile can depend on both.
+  ADR 0010 now accepts the resulting dual-binding model.
+
+- Speculatively explore an IntelliJ integration that presents KlumCast diagnostics directly in the editor and can
+  eventually contribute
+  annotation-aware completion. Stable diagnostic codes, structured arguments, precise source locations, and provenance
+  are enabling contracts. Keep IntelliJ platform dependencies outside the compiler core; assess a query/metadata API only
+  when completion scenarios are concrete. Eclipse integration is lower priority because its incremental compiler already
+  reduces the immediate feedback gap. This is neither a roadmap commitment nor a request for a GitHub issue.
+
+## Issue #455 handoff: Groovy convention plugin
+
+KlumAST already publishes `com.blackbuild.convention.groovy` from its combined `klum-ast-gradle-plugin` artifact. Its wiki
+explicitly says the plugin is not Klum-specific and might be extracted. The implementation selects matching Groovy BOM,
+Groovy, and Spock coordinates across Groovy 3/4/5, handles the `org.codehaus.groovy` to `org.apache.groovy` boundary,
+supports root-project inheritance and skipping Spock, and configures JUnit Platform. Scenario fixtures cover Groovy 3, 4,
+and 5 plus explicit-version and no-Spock cases.
+
+The implementation classes are otherwise generic, but their packages, plugin publication, version lifecycle, and direct
+application by the KlumAST schema/model plugins are currently owned by the KlumAST Gradle-plugin artifact. Extraction could
+give KlumCast and AnnoDocimal a shared dependency-selection convention without depending on KlumAST's combined plugin, but
+the decision must account for plugin-ID/version migration, compatibility with KlumAST's internal application, and whether a
+consumer dependency convention is the same concern as repository test-lane orchestration. Those decisions remain wholly
+owned by KlumAST #455.
+
+The parallel AnnoDocimal architecture session adds one escalation option: if the Groovy module-name transition makes a
+sound shared JPMS design impractical, the libraries may consider dropping Groovy 3 support entirely. Jenkins compatibility
+was the historical reason for retaining Groovy 2.4 so long, so older-Groovy support is not absolute. Dropping Groovy 3 is
+explicitly a last-resort cross-library option, not the current recommendation and not a decision KlumCast makes here.

--- a/docs/implementation/prototypes/check-binding/README.md
+++ b/docs/implementation/prototypes/check-binding/README.md
@@ -1,0 +1,37 @@
+# Check-binding layout proof of concept
+
+This isolated fixture tests the binding alternatives required by provisional ADR 0010. It does not modify KlumCast's
+production API or build.
+
+Run `./run.sh`. By default the script locates the cached Groovy 4.0.12 jar; set `GROOVY_JAR` to exercise another Groovy
+generation. The fixture was run successfully with Groovy 3.0.17 and 4.0.12 on JDK 25.
+
+## Proven results
+
+- An SPI-owned `Class<? extends Check>` binding compiles with a nested check class and rejects `String.class` at compile
+  time. The check/context API directly exposes Groovy `AnnotationNode` and `AnnotatedNode`; no AST abstraction is needed.
+- A metadata-owned `Class<?>` binding keeps metadata independent of SPI and Groovy, but `String.class` compiles. The engine
+  can reject it only when resolving the binding.
+- A name-bound nested check resolves successfully using its binary name with `$`. This works but is materially less
+  ergonomic than a class literal because annotation string values cannot call `Class.getName()`.
+- A name-bound metadata artifact compiles before its implementation artifact even when the check implementation refers
+  back to the control annotation. The corresponding typed layout has no valid separate compilation order: metadata refers
+  to the implementation class and the implementation refers to metadata. Joint compilation works, proving that the
+  problem is artifact dependency direction rather than Java type correctness.
+- Changing an annotation member from `Class<? extends Check>` to `Class<?>` preserves the JVM method descriptor
+  `()Ljava/lang/Class;`. A consumer compiled against the typed form loads with the raw form when its check implementation's
+  SPI/Groovy dependencies are present. This is a viable binary migration bridge, but recompiled consumers lose type
+  checking on that legacy member.
+- Jars named `klum-cast-annotations.jar` and `klum-cast-spi.jar` derive automatic module names `klum.cast.annotations` and
+  `klum.cast.spi`. The SPI requires Groovy because its public context uses Groovy AST types. Groovy 3 derives
+  `org.codehaus.groovy`; Groovy 4 derives `org.apache.groovy`, so an explicit module descriptor or variant-aware module
+  strategy remains coupled to the separate multi-Groovy work in KlumAST #455.
+- The experiment needs no SPI-to-annotations edge. The compiler artifact can depend on both siblings and normalize their
+  binding metadata into SPI-owned invocation data.
+
+## Supported conclusion
+
+The evidence supports keeping both modes with explicit ownership: name binding in the lightweight metadata artifact and
+strong typed binding in the SPI artifact. Co-located or nested check implementations can choose the typed form; cyclic
+split-module layouts use names. The existing mixed binding annotation can become a deprecated raw bridge for a documented
+migration window. Dropping typed binding is possible but is not required by the dependency constraints.

--- a/docs/implementation/prototypes/check-binding/annotations/poc/metadata/NamedCheckBinding.java
+++ b/docs/implementation/prototypes/check-binding/annotations/poc/metadata/NamedCheckBinding.java
@@ -1,0 +1,12 @@
+package poc.metadata;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface NamedCheckBinding {
+    String value();
+}

--- a/docs/implementation/prototypes/check-binding/annotations/poc/metadata/RawCheckBinding.java
+++ b/docs/implementation/prototypes/check-binding/annotations/poc/metadata/RawCheckBinding.java
@@ -1,0 +1,12 @@
+package poc.metadata;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface RawCheckBinding {
+    Class<?> value();
+}

--- a/docs/implementation/prototypes/check-binding/named-nested/poc/consumer/NamedConstraint.java
+++ b/docs/implementation/prototypes/check-binding/named-nested/poc/consumer/NamedConstraint.java
@@ -1,0 +1,22 @@
+package poc.consumer;
+
+import poc.metadata.NamedCheckBinding;
+import poc.spi.CheckContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@NamedCheckBinding("poc.consumer.NamedConstraint$InnerCheck")
+public @interface NamedConstraint {
+    final class InnerCheck implements poc.spi.Check {
+        @Override
+        public List<String> check(CheckContext context) {
+            return List.of(context.annotation().getClassNode().getName());
+        }
+    }
+}

--- a/docs/implementation/prototypes/check-binding/probe/poc/probe/BindingProbe.java
+++ b/docs/implementation/prototypes/check-binding/probe/poc/probe/BindingProbe.java
@@ -1,0 +1,28 @@
+package poc.probe;
+
+import poc.consumer.InvalidRawConstraint;
+import poc.consumer.NamedConstraint;
+import poc.metadata.NamedCheckBinding;
+import poc.metadata.RawCheckBinding;
+import poc.spi.Check;
+
+public final class BindingProbe {
+    private BindingProbe() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        Class<?> rawType = InvalidRawConstraint.class.getAnnotation(RawCheckBinding.class).value();
+        if (Check.class.isAssignableFrom(rawType)) {
+            throw new AssertionError("Raw binding unexpectedly rejected no invalid type");
+        }
+
+        String nestedName = NamedConstraint.class.getAnnotation(NamedCheckBinding.class).value();
+        Class<?> namedType = Class.forName(nestedName);
+        if (!Check.class.isAssignableFrom(namedType)) {
+            throw new AssertionError("Named nested check did not resolve as a Check");
+        }
+
+        System.out.println("raw-invalid-runtime-check=" + rawType.getName());
+        System.out.println("named-nested-resolved=" + namedType.getName());
+    }
+}

--- a/docs/implementation/prototypes/check-binding/raw-invalid/poc/consumer/InvalidRawConstraint.java
+++ b/docs/implementation/prototypes/check-binding/raw-invalid/poc/consumer/InvalidRawConstraint.java
@@ -1,0 +1,14 @@
+package poc.consumer;
+
+import poc.metadata.RawCheckBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@RawCheckBinding(String.class)
+public @interface InvalidRawConstraint {
+}

--- a/docs/implementation/prototypes/check-binding/run.sh
+++ b/docs/implementation/prototypes/check-binding/run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+work="$(mktemp -d "${TMPDIR:-/tmp}/klum-cast-binding-poc.XXXXXX")"
+
+if [[ -z "${GROOVY_JAR:-}" ]]; then
+    GROOVY_JAR="$(rg --files "$HOME/.gradle/caches/modules-2/files-2.1/org.apache.groovy/groovy/4.0.12" | rg '/groovy-4\.0\.12\.jar$' | head -1)"
+fi
+
+if [[ ! -f "$GROOVY_JAR" ]]; then
+    echo "Set GROOVY_JAR to a Groovy compiler jar" >&2
+    exit 2
+fi
+
+mkdir -p "$work/annotations" "$work/spi" "$work/typed-valid" "$work/typed-invalid" \
+    "$work/raw-invalid" "$work/named-nested" "$work/probe" "$work/split-named-meta" \
+    "$work/split-named-impl" "$work/split-typed-meta" "$work/split-typed-impl" "$work/split-typed-together" \
+    "$work/signature-typed" "$work/signature-raw" "$work/signature-consumer" "$work/signature-probe"
+
+javac -d "$work/annotations" \
+    "$root/annotations/poc/metadata/NamedCheckBinding.java" \
+    "$root/annotations/poc/metadata/RawCheckBinding.java"
+jar --create --file "$work/klum-cast-annotations.jar" -C "$work/annotations" .
+
+javac -cp "$GROOVY_JAR" -d "$work/spi" \
+    "$root/spi/poc/spi/Check.java" \
+    "$root/spi/poc/spi/CheckContext.java" \
+    "$root/spi/poc/spi/TypedCheckBinding.java"
+jar --create --file "$work/klum-cast-spi.jar" -C "$work/spi" .
+
+javac -cp "$GROOVY_JAR:$work/klum-cast-spi.jar" -d "$work/typed-valid" \
+    "$root/typed-valid/poc/consumer/TypedConstraint.java"
+
+if javac -cp "$GROOVY_JAR:$work/klum-cast-spi.jar" -d "$work/typed-invalid" \
+    "$root/typed-invalid/poc/consumer/InvalidTypedConstraint.java" 2>"$work/typed-invalid.err"; then
+    echo "Expected the invalid typed binding to fail compilation" >&2
+    exit 1
+fi
+
+javac -cp "$work/klum-cast-annotations.jar" -d "$work/raw-invalid" \
+    "$root/raw-invalid/poc/consumer/InvalidRawConstraint.java"
+
+javac -cp "$GROOVY_JAR:$work/klum-cast-annotations.jar:$work/klum-cast-spi.jar" \
+    -d "$work/named-nested" "$root/named-nested/poc/consumer/NamedConstraint.java"
+
+javac -cp "$GROOVY_JAR:$work/klum-cast-annotations.jar:$work/klum-cast-spi.jar:$work/raw-invalid:$work/named-nested" \
+    -d "$work/probe" "$root/probe/poc/probe/BindingProbe.java"
+
+java -cp "$GROOVY_JAR:$work/klum-cast-annotations.jar:$work/klum-cast-spi.jar:$work/raw-invalid:$work/named-nested:$work/probe" \
+    poc.probe.BindingProbe
+
+javac -cp "$work/klum-cast-annotations.jar" -d "$work/split-named-meta" \
+    "$root/split-named-meta/poc/split/SplitNamedConstraint.java"
+javac -cp "$GROOVY_JAR:$work/klum-cast-spi.jar:$work/split-named-meta" -d "$work/split-named-impl" \
+    "$root/split-named-impl/poc/impl/SplitNamedCheck.java"
+
+if javac -cp "$GROOVY_JAR:$work/klum-cast-spi.jar" -d "$work/split-typed-meta" \
+    "$root/split-typed-meta/poc/split/SplitTypedConstraint.java" 2>"$work/split-typed-meta.err"; then
+    echo "Expected typed metadata to require its implementation artifact" >&2
+    exit 1
+fi
+
+if javac -cp "$GROOVY_JAR:$work/klum-cast-spi.jar" -d "$work/split-typed-impl" \
+    "$root/split-typed-impl/poc/impl/SplitTypedCheck.java" 2>"$work/split-typed-impl.err"; then
+    echo "Expected typed implementation to require its metadata artifact" >&2
+    exit 1
+fi
+
+javac -cp "$GROOVY_JAR:$work/klum-cast-spi.jar" -d "$work/split-typed-together" \
+    "$root/split-typed-meta/poc/split/SplitTypedConstraint.java" \
+    "$root/split-typed-impl/poc/impl/SplitTypedCheck.java"
+
+javac -cp "$GROOVY_JAR:$work/klum-cast-spi.jar" -d "$work/signature-typed" \
+    "$root/signature-typed/poc/compat/Binding.java"
+javac -d "$work/signature-raw" "$root/signature-raw/poc/compat/Binding.java"
+javac -cp "$GROOVY_JAR:$work/klum-cast-spi.jar:$work/signature-typed" -d "$work/signature-consumer" \
+    "$root/signature-consumer/poc/compat/CompatConstraint.java"
+javac -cp "$work/signature-raw:$work/signature-consumer" -d "$work/signature-probe" \
+    "$root/signature-probe/poc/probe/SignatureProbe.java"
+java -cp "$GROOVY_JAR:$work/klum-cast-spi.jar:$work/signature-raw:$work/signature-consumer:$work/signature-probe" \
+    poc.probe.SignatureProbe
+
+typed_descriptor="$(javap -classpath "$work/signature-typed" -s poc.compat.Binding | rg -A1 'value\(\)' | tail -1 | xargs)"
+raw_descriptor="$(javap -classpath "$work/signature-raw" -s poc.compat.Binding | rg -A1 'value\(\)' | tail -1 | xargs)"
+if [[ "$typed_descriptor" != "$raw_descriptor" ]]; then
+    echo "Typed and raw binding descriptors differ" >&2
+    exit 1
+fi
+
+echo "annotations-module=$(jar --describe-module --file "$work/klum-cast-annotations.jar" 2>/dev/null | rg ' automatic$' | head -1)"
+echo "spi-module=$(jar --describe-module --file "$work/klum-cast-spi.jar" 2>/dev/null | rg ' automatic$' | head -1)"
+echo "groovy-module=$(jar --describe-module --file "$GROOVY_JAR" 2>/dev/null | rg ' automatic$' | head -1)"
+echo "spi-dependencies=$(jdeps --ignore-missing-deps --module-path "$GROOVY_JAR" --print-module-deps "$work/klum-cast-spi.jar")"
+echo "typed-valid=compiled"
+echo "typed-invalid=rejected-by-javac"
+echo "raw-invalid=compiled-and-rejected-only-by-runtime-probe"
+echo "split-named=metadata-then-implementation-compiled"
+echo "split-typed=only-joint-compilation-succeeded"
+echo "typed-to-raw-descriptor=$typed_descriptor"
+echo "typed-consumer-with-raw-binding=loaded"
+echo "work=$work"

--- a/docs/implementation/prototypes/check-binding/signature-consumer/poc/compat/CompatConstraint.java
+++ b/docs/implementation/prototypes/check-binding/signature-consumer/poc/compat/CompatConstraint.java
@@ -1,0 +1,21 @@
+package poc.compat;
+
+import poc.spi.CheckContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@Binding(CompatConstraint.InnerCheck.class)
+public @interface CompatConstraint {
+    final class InnerCheck implements poc.spi.Check {
+        @Override
+        public List<String> check(CheckContext context) {
+            return List.of();
+        }
+    }
+}

--- a/docs/implementation/prototypes/check-binding/signature-probe/poc/probe/SignatureProbe.java
+++ b/docs/implementation/prototypes/check-binding/signature-probe/poc/probe/SignatureProbe.java
@@ -1,0 +1,14 @@
+package poc.probe;
+
+import poc.compat.Binding;
+import poc.compat.CompatConstraint;
+
+public final class SignatureProbe {
+    private SignatureProbe() {
+    }
+
+    public static void main(String[] args) {
+        Class<?> value = CompatConstraint.class.getAnnotation(Binding.class).value();
+        System.out.println("typed-consumer-with-raw-binding=" + value.getName());
+    }
+}

--- a/docs/implementation/prototypes/check-binding/signature-raw/poc/compat/Binding.java
+++ b/docs/implementation/prototypes/check-binding/signature-raw/poc/compat/Binding.java
@@ -1,0 +1,12 @@
+package poc.compat;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface Binding {
+    Class<?> value();
+}

--- a/docs/implementation/prototypes/check-binding/signature-typed/poc/compat/Binding.java
+++ b/docs/implementation/prototypes/check-binding/signature-typed/poc/compat/Binding.java
@@ -1,0 +1,14 @@
+package poc.compat;
+
+import poc.spi.Check;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface Binding {
+    Class<? extends Check> value();
+}

--- a/docs/implementation/prototypes/check-binding/spi/poc/spi/Check.java
+++ b/docs/implementation/prototypes/check-binding/spi/poc/spi/Check.java
@@ -1,0 +1,7 @@
+package poc.spi;
+
+import java.util.List;
+
+public interface Check {
+    List<String> check(CheckContext context);
+}

--- a/docs/implementation/prototypes/check-binding/spi/poc/spi/CheckContext.java
+++ b/docs/implementation/prototypes/check-binding/spi/poc/spi/CheckContext.java
@@ -1,0 +1,7 @@
+package poc.spi;
+
+import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+
+public record CheckContext(AnnotationNode annotation, AnnotatedNode target) {
+}

--- a/docs/implementation/prototypes/check-binding/spi/poc/spi/TypedCheckBinding.java
+++ b/docs/implementation/prototypes/check-binding/spi/poc/spi/TypedCheckBinding.java
@@ -1,0 +1,12 @@
+package poc.spi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface TypedCheckBinding {
+    Class<? extends Check> value();
+}

--- a/docs/implementation/prototypes/check-binding/split-named-impl/poc/impl/SplitNamedCheck.java
+++ b/docs/implementation/prototypes/check-binding/split-named-impl/poc/impl/SplitNamedCheck.java
@@ -1,0 +1,16 @@
+package poc.impl;
+
+import poc.spi.Check;
+import poc.spi.CheckContext;
+import poc.split.SplitNamedConstraint;
+
+import java.util.List;
+
+public final class SplitNamedCheck implements Check {
+    private Class<SplitNamedConstraint> controlType = SplitNamedConstraint.class;
+
+    @Override
+    public List<String> check(CheckContext context) {
+        return List.of(controlType.getName());
+    }
+}

--- a/docs/implementation/prototypes/check-binding/split-named-meta/poc/split/SplitNamedConstraint.java
+++ b/docs/implementation/prototypes/check-binding/split-named-meta/poc/split/SplitNamedConstraint.java
@@ -1,0 +1,14 @@
+package poc.split;
+
+import poc.metadata.NamedCheckBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@NamedCheckBinding("poc.impl.SplitNamedCheck")
+public @interface SplitNamedConstraint {
+}

--- a/docs/implementation/prototypes/check-binding/split-typed-impl/poc/impl/SplitTypedCheck.java
+++ b/docs/implementation/prototypes/check-binding/split-typed-impl/poc/impl/SplitTypedCheck.java
@@ -1,0 +1,16 @@
+package poc.impl;
+
+import poc.spi.Check;
+import poc.spi.CheckContext;
+import poc.split.SplitTypedConstraint;
+
+import java.util.List;
+
+public final class SplitTypedCheck implements Check {
+    private Class<SplitTypedConstraint> controlType = SplitTypedConstraint.class;
+
+    @Override
+    public List<String> check(CheckContext context) {
+        return List.of(controlType.getName());
+    }
+}

--- a/docs/implementation/prototypes/check-binding/split-typed-meta/poc/split/SplitTypedConstraint.java
+++ b/docs/implementation/prototypes/check-binding/split-typed-meta/poc/split/SplitTypedConstraint.java
@@ -1,0 +1,15 @@
+package poc.split;
+
+import poc.impl.SplitTypedCheck;
+import poc.spi.TypedCheckBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@TypedCheckBinding(SplitTypedCheck.class)
+public @interface SplitTypedConstraint {
+}

--- a/docs/implementation/prototypes/check-binding/typed-invalid/poc/consumer/InvalidTypedConstraint.java
+++ b/docs/implementation/prototypes/check-binding/typed-invalid/poc/consumer/InvalidTypedConstraint.java
@@ -1,0 +1,14 @@
+package poc.consumer;
+
+import poc.spi.TypedCheckBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@TypedCheckBinding(String.class)
+public @interface InvalidTypedConstraint {
+}

--- a/docs/implementation/prototypes/check-binding/typed-valid/poc/consumer/TypedConstraint.java
+++ b/docs/implementation/prototypes/check-binding/typed-valid/poc/consumer/TypedConstraint.java
@@ -1,0 +1,22 @@
+package poc.consumer;
+
+import poc.spi.CheckContext;
+import poc.spi.TypedCheckBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@TypedCheckBinding(TypedConstraint.InnerCheck.class)
+public @interface TypedConstraint {
+    final class InnerCheck implements poc.spi.Check {
+        @Override
+        public List<String> check(CheckContext context) {
+            return List.of(context.annotation().getClassNode().getName());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- establish the KlumCast repository governance baseline with `AGENTS.md`, `CONTEXT.md`, agent guidance, ADR conventions,
  and reusable grilling/domain-modeling workflows
- record the library-native architecture decisions for the 0.4 migration and clean 1.0 compatibility baseline
- add a reproducible binding-layout proof of concept covering typed, raw, and name-based bindings
- document the KlumAST consumer findings, validation-ownership boundaries, coverage seams, and the separate #455 handoff

## Architecture outcome

The accepted target separates lightweight annotations, the Groovy-dependent public SPI, and compiler activation into
`klum-cast-annotations`, `klum-cast-spi`, and `klum-cast-compile`. It defines immutable check context, interface-based
checks and filters, dual typed/name bindings, structured diagnostics, stable automatic-module names, and a documented
0.4 migration line before the bridge-free 1.0 contract.

The repository-owned plan links umbrella #24 and focused issues #12, #16, #17, #22, and #23. Multi-Groovy build and
support decisions remain outside this PR and coordinated through KlumAST #455.

## Impact

This PR changes documentation, repository governance, and an isolated design fixture only. It does not change production
API, build behavior, published dependencies, compiler activation, or release artifacts.

## Validation

- binding POC passed with Groovy 3.0.17 and 4.0.12
- valid nested typed checks compiled and invalid typed checks were rejected by `javac`
- name-bound split modules compiled in dependency order; the typed cyclic layout required joint compilation
- typed-to-raw annotation-member descriptor compatibility and runtime loading were verified
- automatic module identities and SPI-to-Groovy dependency were inspected
- `git diff --check origin/main...HEAD`

Related: #24, #12, #16, #17, #22, #23.
