### PR TITLE
Guard issue references from GitHub closing syntax

### DIFF
--- a/docs/agents/commits.md
+++ b/docs/agents/commits.md
@@ -10,6 +10,9 @@
 ## Reasoned commits
 
 - Make each commit one self-contained reasoning step with a concise imperative subject.
+- Treat commit subjects and bodies as GitHub issue-linking input. Do not place a GitHub closing keyword before an issue
+  reference unless merging that commit is intended to close the issue automatically; negated wording can still trigger
+  GitHub's pattern matching. Use neutral issue references as described in `docs/agents/pull-requests.md`.
 - Keep a test and the production change that makes it pass in the same commit.
 - Run the relevant verification before each commit. A deliberately transitional commit must make the reasoning clearer,
   be repaired immediately, and explain the boundary.

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -3,6 +3,11 @@
 ## Scope and issue links
 
 - Use closing keywords only for issues whose confirmed behavior is fully delivered.
+- Treat GitHub closing keywords as mechanical syntax, not prose. In pull-request titles and bodies, never place `close`,
+  `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, or `resolved` before an issue reference unless the
+  pull request is intended to close that issue automatically. Negation, quotation, code formatting, and explanatory
+  context do not make the pattern safe. For non-closing relationships, use neutral wording such as `Related: #123`,
+  `Issue #123 remains open`, or `This pull request leaves the issue state unchanged`.
 - Reference related work that remains deferred and state explicitly what the pull request does not implement.
 - Keep the summary, compatibility impact, and validation evidence current as commits are added.
 


### PR DESCRIPTION
## Summary

- treat GitHub closing keywords as mechanical syntax in pull-request and commit text
- require neutral wording for relationships that must not change issue state

## Validation

- git diff --check